### PR TITLE
Add a sql specific container block

### DIFF
--- a/templates/cosmos-db-sql-container.json
+++ b/templates/cosmos-db-sql-container.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "accountName": {
+      "type": "string"
+    },
+    "databaseName": {
+      "type": "string"
+    },
+    "containerName": {
+      "type": "string"
+    },
+    "partitionKeyPaths": {
+      "type": "array",
+      "defaultValue": []
+    },
+    "partitionKeyKind": {
+      "type": "string",
+      "defaultValue": "Hash",
+      "allowedValues": [
+        "Hash",
+        "Range"
+      ]
+    }
+  },
+  "variables": {
+    "partitionKeySettings": {
+      "paths": "[parameters('partitionKeyPaths')]",
+      "kind": "[parameters('partitionKeyKind')]"
+    }
+  },
+  "resources": [
+    {
+			"type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
+			"name": "[concat(parameters('accountName'), '/', parameters('databaseName'), '/', parameters('containerName'))]",      
+      "apiVersion": "2020-03-01",
+      "properties": {
+        "resource": {
+          "id": "[parameters('containerName')]",
+          "partitionKey": "[if(greater(length(parameters('partitionKeyPaths')), 0), variables('partitionKeySettings'), json('null'))]"
+        }
+      }
+    }
+  ]
+}

--- a/templates/cosmos-db-sql-container.json
+++ b/templates/cosmos-db-sql-container.json
@@ -13,7 +13,8 @@
     },
     "partitionKeyPaths": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": [
+      ]
     },
     "partitionKeyKind": {
       "type": "string",
@@ -32,8 +33,8 @@
   },
   "resources": [
     {
-			"type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
-			"name": "[concat(parameters('accountName'), '/', parameters('databaseName'), '/', parameters('containerName'))]",      
+      "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
+      "name": "[concat(parameters('accountName'), '/', parameters('databaseName'), '/', parameters('containerName'))]",
       "apiVersion": "2020-03-01",
       "properties": {
         "resource": {


### PR DESCRIPTION
The cosmos api has progressed since the original blocks were created. I think that is now worth having separate cosmos-container blocks per supported type allowing for the differences in configuration without making an over-crowded parent template.

The idea is that as this block develops, settings should be added with conditions to allow reasonable choice when creating a resource.