### PR TITLE
Updated template for Classic app service logging

### DIFF
--- a/templates/app-service-logging.json
+++ b/templates/app-service-logging.json
@@ -78,17 +78,17 @@
     }
   },
   "variables": {
-    "ApplicationLogBlobName": "[concat(parameters('appServiceResourceName'),'-application-logs')]",
-    "HttpLogBlobName": "[concat(parameters('appServiceResourceName'),'-webserver-logs')]",
+    "applicationLogBlobName": "[concat(parameters('appServiceResourceName'),'-application-logs')]",
+    "httpLogBlobName": "[concat(parameters('appServiceResourceName'),'-webserver-logs')]",
     "serviceSasApplicationProperties": {
-      "canonicalizedResource": "[concat('/blob/', parameters('sharedLogStorageAccount'), '/', variables('ApplicationLogBlobName'))]",
+      "canonicalizedResource": "[concat('/blob/', parameters('sharedLogStorageAccount'), '/', variables('applicationLogBlobName'))]",
       "signedVersion ": "2018-03-28",
       "signedResource": "c",
       "signedPermission": "rwdl",
       "signedExpiry": "2045-01-01T00:00:00Z"
     },
     "serviceSasWebServerProperties": {
-      "canonicalizedResource": "[concat('/blob/', parameters('sharedLogStorageAccount'), '/', variables('HttpLogBlobName'))]",
+      "canonicalizedResource": "[concat('/blob/', parameters('sharedLogStorageAccount'), '/', variables('httpLogBlobName'))]",
       "signedVersion ": "2018-03-28",
       "signedResource": "c",
       "signedPermission": "rwdl",
@@ -110,7 +110,7 @@
           "azureBlobStorage": {
             "level": "[parameters('applogToBlob')]",
             "retentionInDays": "[parameters('appServiceLogRetentionDays')]",
-            "sasUrl": "[concat('https://', parameters('sharedLogStorageAccount'), '.blob.core.windows.net/', variables('ApplicationLogBlobName'), '?', listServiceSas(concat('Microsoft.Storage/storageAccounts/', parameters('sharedLogStorageAccount')), '2018-07-01', variables('serviceSasApplicationProperties')).serviceSasToken)]"
+            "sasUrl": "[concat('https://', parameters('sharedLogStorageAccount'), '.blob.core.windows.net/', variables('applicationLogBlobName'), '?', listServiceSas(concat('Microsoft.Storage/storageAccounts/', parameters('sharedLogStorageAccount')), '2018-07-01', variables('serviceSasApplicationProperties')).serviceSasToken)]"
           }
         },
         "httpLogs": {
@@ -122,7 +122,7 @@
           "azureBlobStorage": {
             "enabled": "[parameters('weblogToBlob')]",
             "retentionInDays": "[parameters('appServiceLogRetentionDays')]",
-            "sasUrl": "[concat('https://', parameters('sharedLogStorageAccount'), '.blob.core.windows.net/', variables('HttpLogBlobName'), '?', listServiceSas(concat('Microsoft.Storage/storageAccounts/', parameters('sharedLogStorageAccount')), '2018-07-01', variables('serviceSasWebServerProperties')).serviceSasToken)]"
+            "sasUrl": "[concat('https://', parameters('sharedLogStorageAccount'), '.blob.core.windows.net/', variables('httpLogBlobName'), '?', listServiceSas(concat('Microsoft.Storage/storageAccounts/', parameters('sharedLogStorageAccount')), '2018-07-01', variables('serviceSasWebServerProperties')).serviceSasToken)]"
           }
         },
         "failedRequestsTracing": {

--- a/templates/app-service-logging.json
+++ b/templates/app-service-logging.json
@@ -78,22 +78,22 @@
     }
   },
   "variables": {
-      "ApplicationLogBlobName": "[concat(parameters('appServiceResourceName'),'-application-logs')]",
-      "HttpLogBlobName": "[concat(parameters('appServiceResourceName'),'webserver-logs')]",
-      "serviceSasApplicationProperties": {
-            "canonicalizedResource": "[concat('/blob/', parameters('sharedLogStorageAccount'), '/', variables('ApplicationLogBlobName'))]",
-            "signedVersion ": "2018-03-28",
-            "signedResource": "c",
-            "signedPermission": "rwdl",
-            "signedExpiry": "2045-01-01T00:00:00Z"
-        },
-      "serviceSasWebServerProperties": {
-            "canonicalizedResource": "[concat('/blob/', parameters('sharedLogStorageAccount'), '/', variables('HttpLogBlobName'))]",
-            "signedVersion ": "2018-03-28",
-            "signedResource": "c",
-            "signedPermission": "rwdl",
-            "signedExpiry": "2045-01-01T00:00:00Z"
-        }
+    "ApplicationLogBlobName": "[concat(parameters('appServiceResourceName'),'-application-logs')]",
+    "HttpLogBlobName": "[concat(parameters('appServiceResourceName'),'webserver-logs')]",
+    "serviceSasApplicationProperties": {
+      "canonicalizedResource": "[concat('/blob/', parameters('sharedLogStorageAccount'), '/', variables('ApplicationLogBlobName'))]",
+      "signedVersion ": "2018-03-28",
+      "signedResource": "c",
+      "signedPermission": "rwdl",
+      "signedExpiry": "2045-01-01T00:00:00Z"
+    },
+    "serviceSasWebServerProperties": {
+      "canonicalizedResource": "[concat('/blob/', parameters('sharedLogStorageAccount'), '/', variables('HttpLogBlobName'))]",
+      "signedVersion ": "2018-03-28",
+      "signedResource": "c",
+      "signedPermission": "rwdl",
+      "signedExpiry": "2045-01-01T00:00:00Z"
+    }
   },
   "resources": [
     {
@@ -110,7 +110,7 @@
           "azureBlobStorage": {
             "level": "[parameters('applogToBlob')]",
             "retentionInDays": "[parameters('appServiceLogRetentionDays')]",
-            "sasUrl":"[concat('https://', parameters('sharedLogStorageAccount'), '.blob.core.windows.net/', variables('ApplicationLogBlobName'), '?', listServiceSas(concat('Microsoft.Storage/storageAccounts/', parameters('sharedLogStorageAccount')), '2018-07-01', variables('serviceSasApplicationProperties')).serviceSasToken)]"
+            "sasUrl": "[concat('https://', parameters('sharedLogStorageAccount'), '.blob.core.windows.net/', variables('ApplicationLogBlobName'), '?', listServiceSas(concat('Microsoft.Storage/storageAccounts/', parameters('sharedLogStorageAccount')), '2018-07-01', variables('serviceSasApplicationProperties')).serviceSasToken)]"
           }
         },
         "httpLogs": {
@@ -119,8 +119,8 @@
             "retentionInDays": "[parameters('appServiceLogRetentionDays')]",
             "enabled": "[parameters('weblogToFs')]"
           },
-        "azureBlobStorage": {
-            "level": "[parameters('weblogToBlob')]",
+          "azureBlobStorage": {
+            "enabled": "[parameters('weblogToBlob')]",
             "retentionInDays": "[parameters('appServiceLogRetentionDays')]",
             "sasUrl": "[concat('https://', parameters('sharedLogStorageAccount'), '.blob.core.windows.net/', variables('HttpLogBlobName'), '?', listServiceSas(concat('Microsoft.Storage/storageAccounts/', parameters('sharedLogStorageAccount')), '2018-07-01', variables('serviceSasWebServerProperties')).serviceSasToken)]"
           }

--- a/templates/app-service-logging.json
+++ b/templates/app-service-logging.json
@@ -12,9 +12,88 @@
     "appServiceLogRetentionMb": {
       "type": "string",
       "defaultValue": "30"
+    },
+    "applogToFs": {
+      "type": "string",
+      "defaultValue": "Off",
+      "allowedValues": [
+        "Off",
+        "Warning",
+        "Error",
+        "Information",
+        "Verbose"
+      ],
+      "metadata": {
+        "description": "Log Application Logs to Filesystem, default is Off"
+      }
+    },
+    "applogToBlob": {
+      "type": "string",
+      "defaultValue": "Off",
+      "allowedValues": [
+        "Off",
+        "Warning",
+        "Error",
+        "Information",
+        "Verbose"
+      ],
+      "metadata": {
+        "description": "Log Application Logs to Filesystem, default is Off"
+      }
+    },
+    "weblogToFs": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Log HTTP Logs to Filesystem, default is False"
+      }
+    },
+    "weblogToBlob": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Log HTTP Logs to Blob, default is False"
+      }
+    },
+    "failedRequestTracing": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Turn on failedRequestTracing, default is True"
+      }
+    },
+    "detailedErrorMessages": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Turn on detailedErrorMessages, default is True"
+      }
+    },
+    "sharedLogStorageAccount": {
+      "defaultValue": "",
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Shared Storage Account for application and web server logging for this resource"
+      }
     }
   },
   "variables": {
+      "ApplicationLogBlobName": "[concat(parameters('appServiceResourceName'),'-application-logs')]",
+      "HttpLogBlobName": "[concat(parameters('appServiceResourceName'),'webserver-logs')]",
+      "serviceSasApplicationProperties": {
+            "canonicalizedResource": "[concat('/blob/', parameters('sharedLogStorageAccount'), '/', variables('ApplicationLogBlobName'))]",
+            "signedVersion ": "2018-03-28",
+            "signedResource": "c",
+            "signedPermission": "rwdl",
+            "signedExpiry": "2045-01-01T00:00:00Z"
+        },
+      "serviceSasWebServerProperties": {
+            "canonicalizedResource": "[concat('/blob/', parameters('sharedLogStorageAccount'), '/', variables('HttpLogBlobName'))]",
+            "signedVersion ": "2018-03-28",
+            "signedResource": "c",
+            "signedPermission": "rwdl",
+            "signedExpiry": "2045-01-01T00:00:00Z"
+        }
   },
   "resources": [
     {
@@ -26,34 +105,35 @@
       "properties": {
         "applicationLogs": {
           "fileSystem": {
-            "level": "Off"
-          },
-          "azureTableStorage": {
-            "level": "Off",
-            "sasUrl": null
+            "level": "[parameters('applogToFs')]"
           },
           "azureBlobStorage": {
-            "level": "verbose",
-            "retentionInDays": "[parameters('appServiceLogRetentionDays')]"
+            "level": "[parameters('applogToBlob')]",
+            "retentionInDays": "[parameters('appServiceLogRetentionDays')]",
+            "sasUrl":"[concat('https://', parameters('sharedLogStorageAccount'), '.blob.core.windows.net/', variables('ApplicationLogBlobName'), '?', listServiceSas(concat('Microsoft.Storage/storageAccounts/', parameters('sharedLogStorageAccount')), '2018-07-01', variables('serviceSasApplicationProperties')).serviceSasToken)]"
           }
         },
         "httpLogs": {
           "fileSystem": {
             "retentionInMb": "[parameters('appServiceLogRetentionMb')]",
             "retentionInDays": "[parameters('appServiceLogRetentionDays')]",
-            "enabled": true
+            "enabled": "[parameters('weblogToFs')]"
+          },
+        "azureBlobStorage": {
+            "level": "[parameters('weblogToBlob')]",
+            "retentionInDays": "[parameters('appServiceLogRetentionDays')]",
+            "sasUrl": "[concat('https://', parameters('sharedLogStorageAccount'), '.blob.core.windows.net/', variables('HttpLogBlobName'), '?', listServiceSas(concat('Microsoft.Storage/storageAccounts/', parameters('sharedLogStorageAccount')), '2018-07-01', variables('serviceSasWebServerProperties')).serviceSasToken)]"
           }
         },
         "failedRequestsTracing": {
-          "enabled": true
+          "enabled": "[parameters('failedRequestTracing')]"
         },
         "detailedErrorMessages": {
-          "enabled": true
+          "enabled": "[parameters('detailedErrorMessages')]"
         }
       }
     }
   ],
   "outputs": {
-
   }
 }

--- a/templates/app-service-logging.json
+++ b/templates/app-service-logging.json
@@ -79,7 +79,7 @@
   },
   "variables": {
     "ApplicationLogBlobName": "[concat(parameters('appServiceResourceName'),'-application-logs')]",
-    "HttpLogBlobName": "[concat(parameters('appServiceResourceName'),'webserver-logs')]",
+    "HttpLogBlobName": "[concat(parameters('appServiceResourceName'),'-webserver-logs')]",
     "serviceSasApplicationProperties": {
       "canonicalizedResource": "[concat('/blob/', parameters('sharedLogStorageAccount'), '/', variables('ApplicationLogBlobName'))]",
       "signedVersion ": "2018-03-28",


### PR DESCRIPTION
Added parameters for turning on Application Logging FS and Blob, Web server Logging FS and Blob.  Added parameters to control detailErrorMessages and failedRequestTracing which are on by default.
Removed Table Storage option.
Creates a service SAS to specify destination blob in template via listServiceSaS
Switch logging off by Default assumes the user wants to choose their own logs and level, gives control over error messages and tracing.