### PR TITLE
Ms/features/30316 functionapp diagnostics

### DIFF
--- a/templates/function-app.json
+++ b/templates/function-app.json
@@ -53,6 +53,42 @@
         "FtpsOnly",
         "Disabled"
       ]
+    },
+    "settingName": {
+      "type": "String",
+      "defaultvalue": "AppServiceDiagSettings",
+      "metadata": {
+        "description": "The name of the diagnostic setting"
+      }
+    },
+    "workspaceId": {
+      "type": "String",
+      "defaultValue": "",
+      "metadata": {
+        "description": "ResourceID of the Log Analytics workspace in which resource logs should be saved."
+      }
+    },
+    "functionAppLogs": {
+      "type": "bool",
+      "defaultvalue": false,
+      "metadata": {
+        "description": "Function App Log diagnostic setting"
+      }
+    },
+    "allMetricsSetting": {
+      "type": "bool",
+      "defaultvalue": false,
+      "metadata": {
+        "description": "All Metrics diagnostic setting"
+      }
+    },
+    "retentionPolicyEnabled": {
+      "type": "bool",
+      "defaultValue": false
+    },
+    "retentionPolicyDays": {
+      "type": "string",
+      "defaultValue": "30"
     }
   },
   "variables": {
@@ -110,6 +146,39 @@
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites', parameters('functionAppName'))]"
       ]
+    },
+    {
+      "type": "Microsoft.Web/sites/providers/diagnosticSettings",
+      "condition": "[greater(length(parameters('workspaceId')), 0)]",
+      "apiVersion": "2017-05-01-preview",
+      "name": "[concat(parameters('functionAppName'),'/microsoft.insights/', parameters('settingName'))]",
+      "dependsOn": [
+        "[parameters('functionAppName')]"
+      ],
+      "properties": {
+        "name": "[parameters('settingName')]",
+        "workspaceId": "[parameters('workspaceId')]",
+        "logs": [
+          {
+            "category": "FunctionAppLogs",
+            "enabled": "[parameters('functionAppLogs')]",
+            "retentionPolicy": {
+              "enabled": "[parameters('retentionPolicyEnabled')]",
+              "days": "[parameters('retentionPolicyDays')]"
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "category": "AllMetrics",
+            "enabled": "[parameters('allMetricsSetting')]",
+            "retentionPolicy": {
+              "enabled": "[parameters('retentionPolicyEnabled')]",
+              "days": "[parameters('retentionPolicyDays')]"
+            }
+          }
+        ]
+      }
     }
   ],
   "outputs": {

--- a/templates/function-app.json
+++ b/templates/function-app.json
@@ -56,7 +56,7 @@
     },
     "settingName": {
       "type": "String",
-      "defaultvalue": "AppServiceDiagSettings",
+      "defaultvalue": "FunctionAppDiagSettings",
       "metadata": {
         "description": "The name of the diagnostic setting"
       }
@@ -84,11 +84,17 @@
     },
     "retentionPolicyEnabled": {
       "type": "bool",
-      "defaultValue": false
+      "defaultValue": false,
+      "metadata": {
+        "description": "Function App diagnostic Retention Policy"
+      }
     },
     "retentionPolicyDays": {
       "type": "string",
-      "defaultValue": "30"
+      "defaultValue": "30",
+      "metadata": {
+        "description": "Function App diagnostic Retention Policy in Days"
+      }
     }
   },
   "variables": {


### PR DESCRIPTION
Add to Template Diagnostics Settings for Function Apps.  Provides for AllMetrics and FunctionAppLogs off by default, together with allowing for enabling Retention Policy and settings days.

Ran tests deploying the template with the default settings of false for both AllMetrics and FunctionAppLogs.