### PR TITLE
Add Servicebus diagnostics

### DIFF
--- a/templates/service-bus-diagnostics.json
+++ b/templates/service-bus-diagnostics.json
@@ -1,0 +1,86 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "enableAllMetrics": {
+            "type": "bool",
+            "defaultValue": true,
+            "metadata": {
+                "description": "Collect allMetrics"
+            }
+        },
+        "enableOperationalLogs": {
+            "type": "bool",
+            "defaultValue": true,
+            "metadata": {
+                "description": "Collect Operational Logs"
+            }
+        },
+        "ServiceBusName": {
+            "type": "string"
+        },
+        "setRetentionPolicyDays": {
+            "type": "string",
+            "defaultValue": "30",
+            "metadata": {
+                "description": "The number of days for the Retention policy"
+            }
+        },
+        "enableRetentionPolicy": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Indicates whether Retention Policy is enabled"
+            }
+        },
+        "settingName": {
+            "type": "String",
+            "defaultvalue": "ServiceBusDiagSettings",
+            "metadata": {
+                "description": "The name of the diagnostic setting"
+            }
+        },
+        "sharedWorkspaceID": {
+            "type": "string",
+            "metadata": {
+                "description": "The Shared WorkspaceID should be the Workspace ResourceID Value"
+            }
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.ServiceBus/namespaces/providers/diagnosticSettings",
+            "apiVersion": "2017-05-01-preview",
+            "name": "[concat(parameters('ServiceBusName'),'/microsoft.insights/', parameters('settingName'))]",
+            "dependsOn": [
+            ],
+            "properties": {
+                "name": "[parameters('settingName')]",
+
+                "metrics": [
+                    {
+                        "category": "AllMetrics",
+                        "enabled": "[parameters('enableAllMetrics')]",
+                        "retentionPolicy": {
+                            "enabled": "[parameters('enableRetentionPolicy')]",
+                            "days": "[parameters('setRetentionPolicyDays')]"
+                        }
+                    }
+                ],
+                "logs": [
+                    {
+                        "category": "OperationalLogs",
+                        "enabled": "[parameters('enableOperationalLogs')]",
+                        "retentionPolicy": {
+                            "enabled": "[parameters('enableRetentionPolicy')]",
+                            "days": "[parameters('setRetentionPolicyDays')]"
+                        }
+                    }
+                ],
+                "workspaceId": "[parameters('sharedWorkspaceID')]"
+            }
+        }
+    ],
+    "outputs": {}
+}


### PR DESCRIPTION
Add Service-bus Diagnostic template.  Turn on AllMetrics and Operationallogs by default.  Retention Policy is off by default.

Tested in my test Subscription.