### PR TITLE
Avoid resetting access policies when no access policy is defined

### DIFF
--- a/templates/keyvault.json
+++ b/templates/keyvault.json
@@ -61,24 +61,30 @@
       "defaultValue": "30"
     }
   },
-  "variables": {},
+  "variables": {
+    "defaultProperties": {
+        "enabledForDiskEncryption": "[parameters('enabledForDiskEncryption')]",
+        "enabledForTemplateDeployment": "[parameters('enabledForTemplateDeployment')]",
+        "enableSoftDelete": "[parameters('enableSoftDelete')]",
+        "tenantId": "[subscription().tenantId]",
+        "sku": {
+          "name": "Standard",
+          "family": "A"
+        }
+    },
+    "accessPolicyProperty": {
+        "accessPolicies": "[parameters('keyVaultAccessPolicies')]",
+    },
+    "allProperties": "[if(empty(parameters('keyVaultAccessPolicies')), variables('defaultProperties'), union(variables('defaultProperties'), variables('accessPolicyProperty')))]"
+
+  },
   "resources": [
     {
       "type": "Microsoft.KeyVault/vaults",
       "name": "[parameters('keyVaultName')]",
       "apiVersion": "2018-02-14",
       "location": "[resourceGroup().location]",
-      "properties": {
-        "enabledForDiskEncryption": "[parameters('enabledForDiskEncryption')]",
-        "enabledForTemplateDeployment": "[parameters('enabledForTemplateDeployment')]",
-        "enableSoftDelete": "[parameters('enableSoftDelete')]",
-        "accessPolicies": "[parameters('keyVaultAccessPolicies')]",
-        "tenantId": "[subscription().tenantId]",
-        "sku": {
-          "name": "Standard",
-          "family": "A"
-        }
-      }
+      "properties": "[variables('allProperties')]"
     },
     {
       "type": "Microsoft.KeyVault/vaults/providers/diagnosticSettings",


### PR DESCRIPTION
When deploying the building block with no access policy set,  all existing access policies are removed.
This leads to unwanted behaviour when deploying the building block as part of shared infrastructure,
especially when app-specific templates that create resources with managed identities are used.

Note that if an access policy is supplied to the building block, all other access policies not in the building block are still removed