### PR TITLE
Change version to 2017-05-01-preview

### DIFF
--- a/templates/app-service.json
+++ b/templates/app-service.json
@@ -291,7 +291,7 @@
     {
       "type": "Microsoft.Web/sites/providers/diagnosticSettings",
       "condition": "[greater(length(parameters('workspaceId')), 0)]",
-      "apiVersion": "2016-09-01",
+      "apiVersion": "2017-05-01-preview",
       "name": "[concat(parameters('appServiceName'),'/microsoft.insights/', parameters('settingName'))]",
       "dependsOn": [
         "[parameters('appServiceName')]"


### PR DESCRIPTION
Change API Version for Azure Diagnostics to 2017-05-01-preview.  This was the version diagnostics ran on during the last successful deployment.