### PR TITLE
Add resourceTags to app-service-certificate template

### DIFF
--- a/templates/app-service-certificate.json
+++ b/templates/app-service-certificate.json
@@ -2,6 +2,21 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+        "environmentTag": {
+        "type": "string"
+    },
+    "parentBusinessTag": {
+        "type": "string"
+    },
+    "portfolioTag": {
+        "type": "string"
+    },
+    "productTag": {
+        "type": "string"
+    },
+    "serviceLineTag": {
+        "type": "string"
+    },
     "keyVaultCertificateName": {
       "type": "string"
     },
@@ -36,6 +51,15 @@
       "name": "[parameters('keyVaultCertificateName')]",
       "location": "[resourceGroup().location]",
       "apiVersion": "2016-03-01",
+            "tags": {
+          "Environment": "[parameters('environmentTag')]",
+          "Parent Business": "[parameters('parentBusinessTag')]",
+          "Portfolio": "[parameters('portfolioTag')]",
+          "Product": "[parameters('productTag')]",
+          "Service": "[parameters('productTag')]",
+          "Service Line": "[parameters('serviceLineTag')]",
+          "Service Offering": "[parameters('productTag')]"
+      },
       "properties": "[if(variables('includeServerFarmId'), variables('certificateResourceProperties').withServerFarmId, variables('certificateResourceProperties').withoutServerFarmId)]"
     }
   ],


### PR DESCRIPTION
FCS uses the template app-service-certificate which needs resourceTags added.