### PR TITLE
fix<tls>: correct json path of tls cypher suite setting

### DIFF
--- a/templates/app-service.json
+++ b/templates/app-service.json
@@ -226,11 +226,11 @@
           "use32BitWorkerProcess": "[parameters('use32BitWorkerProcess')]",
           "http20Enabled": "[parameters('http20Enabled')]",
           "ftpsState": "[parameters('ftpsState')]",
-          "healthCheckPath": "[parameters('healthCheckPath')]"
+          "healthCheckPath": "[parameters('healthCheckPath')]",
+          "minTlsCipherSuite": "[parameters('minTlsCipherSuite')]"
         },
         "httpsOnly": true,
-        "minTlsVersion": "[parameters('minTlsVersion')]",
-        "minTlsCipherSuite": "[parameters('minTlsCipherSuite')]"
+        "minTlsVersion": "[parameters('minTlsVersion')]""
       },
       "resources": [
         {


### PR DESCRIPTION
After support with Microsoft, the following correction should allow the settings of the minimum TLS cypher suit setting.