### PR TITLE
Update sql-server.json minimum TLS settings

### DIFF
--- a/templates/sql-server.json
+++ b/templates/sql-server.json
@@ -49,7 +49,7 @@
     },
     "sqlServerminimalTlsVersion": {
       "type": "string",
-      "defaultValue": "1.0",
+      "defaultValue": "1.2",
       "metadata": {
         "description": "Minumum TLS Version"
       }


### PR DESCRIPTION
Azure has announced that support for older TLS versions (TLS 1.0, and 1.1) ends August 31, 2025. For more information, see TLS 1.0 and 1.1 deprecation .

Starting November 2024, you will no longer be able to set the minimal TLS version for Azure SQL Database client connections below TLS 1.2.