### PR TITLE
Reverting TLS version

### DIFF
--- a/templates/app-service-zero-downtime-deploy.json
+++ b/templates/app-service-zero-downtime-deploy.json
@@ -178,7 +178,7 @@
     },
     "minTlsVersion": {
       "type": "string",
-      "defaultValue": "1.3",
+      "defaultValue": "1.2",
       "allowedValues": [
         "1.0",
         "1.1",


### PR DESCRIPTION
Reverting the TLS version to 1.2 on app-service-zero-downtime-deploy.json template