### PR TITLE
Add Linux Function App support to shared ARM template

### DIFF
--- a/templates/function-app.json
+++ b/templates/function-app.json
@@ -31,6 +31,10 @@
     "appServicePlanName": {
       "type": "string"
     },
+    "functionAppKind": {
+      "type": "string",
+      "defaultValue": "functionapp"
+    },
     "appServicePlanResourceGroup": {
       "type": "string"
     },
@@ -170,7 +174,7 @@
     {
       "name": "[parameters('functionAppName')]",
       "type": "Microsoft.Web/sites",
-      "kind": "functionapp",
+      "kind": "[parameters('functionAppKind')]",
       "apiVersion": "[variables('functionAppApiVersion')]",
       "location": "[resourceGroup().location]",
       "identity": {
@@ -187,6 +191,7 @@
       },
       "properties": {
         "serverFarmId": "[variables('appServicePlanId')]",
+        "reserved": "[equals(parameters('functionAppKind'), 'functionapp,linux')]",
         "clientAffinityEnabled": false,
         "clientCertEnabled": "[parameters('clientCertEnabled')]",
         "clientCertMode": "[parameters('clientCertMode')]",


### PR DESCRIPTION
Summary

Updates the shared Function App ARM template to support deployment onto Linux App Service Plans.

Changes
Added parameter support for Function App kind (functionAppKind)
Updated kind field to be parameterised instead of hardcoded
Introduced support for Linux Function App configuration via optional parameters
Ensured existing Windows Function Apps continue to deploy unchanged via default values
Updated shared template integration to allow FileDetails Function App migration to Linux plan

Notes
Default behaviour remains Windows (functionapp) to avoid breaking existing deployments
Linux-specific configuration is only applied when explicitly passed via parameters
This change is required to support migrating FileDetails Function App onto a Linux App Service Plan

Impact
No impact to existing Windows Function Apps
Enables creation/deployment of Linux Function Apps using the same shared template
Required for ongoing Digital Forms migration to linux work