### PR TITLE
Function app linux

### DIFF
--- a/templates/function-app.json
+++ b/templates/function-app.json
@@ -33,7 +33,7 @@
     },
     "functionAppKind": {
       "type": "string",
-      "defaultValue": "functionapp,linux"
+      "defaultValue": "functionapp"
     },
     "appServicePlanResourceGroup": {
       "type": "string"
@@ -141,6 +141,13 @@
         "link": "https://learn.microsoft.com/en-us/answers/questions/835272/azure-functions-pinned-to-unsupported-dotnet-runti.html"
       }
     },
+    "linuxFxVersion": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Linux runtime stack, e.g. DOTNET-ISOLATED|8.0"
+      }
+    },
     "minTlsVersion": {
       "type": "string",
       "defaultValue": "1.2",
@@ -168,7 +175,10 @@
     "siteConfigNetFrameworkVersion": {
       "netFrameworkVersion": "[parameters('netFrameworkVersion')]"
     },
-    "siteConfig": "[if(greater(length(parameters('netFrameworkVersion')), 0),  union(variables('baseSiteConfig'), variables('siteConfigNetFrameworkVersion')), variables('baseSiteConfig'))]"
+    "siteConfigLinuxFxVersion": {
+      "linuxFxVersion": "[parameters('linuxFxVersion')]"
+    },
+    "siteConfig": "[union(variables('baseSiteConfig'),if(greater(length(parameters('netFrameworkVersion')), 0), variables('siteConfigNetFrameworkVersion'), createObject()),if(greater(length(parameters('linuxFxVersion')), 0), variables('siteConfigLinuxFxVersion'), createObject()))]"
   },
   "resources": [
     {

--- a/templates/function-app.json
+++ b/templates/function-app.json
@@ -33,7 +33,7 @@
     },
     "functionAppKind": {
       "type": "string",
-      "defaultValue": "functionapp"
+      "defaultValue": "functionapp,linux"
     },
     "appServicePlanResourceGroup": {
       "type": "string"


### PR DESCRIPTION
Updated shared Function App ARM template to support `linuxFxVersion` configuration for Linux Function Apps running .NET isolated.

Previously, the template only configured `netFrameworkVersion`, which does not set the Linux runtime stack. Added an optional `linuxFxVersion` parameter and applied it conditionally through `siteConfig` so existing Function Apps remain unaffected.

This allows Linux isolated Function Apps to explicitly configure the required runtime (e.g. `DOTNET-ISOLATED|8.0`) during deployment instead of requiring manual Portal changes.